### PR TITLE
scala 2.12.2, akka 2.5.1 and sangria 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,20 +3,24 @@ version := "0.1.0-SNAPSHOT"
 
 description := "Sangria Subscriptions Example"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.0.0",
+  "org.sangria-graphql" %% "sangria" % "1.2.0",
   "org.sangria-graphql" %% "sangria-spray-json" % "1.0.0",
   "org.sangria-graphql" %% "sangria-akka-streams" % "1.0.0",
 
-  "com.typesafe.akka" %% "akka-http" % "10.0.1",
-  "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.1",
+  "com.typesafe.akka" %% "akka-http" % "10.0.6",
+  "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.6",
   "de.heikoseeberger" %% "akka-sse" % "2.0.0",
 
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.typesafe.akka" %% "akka-stream-testkit" % "2.4.16" % "test"
+
+  // akka-http still depends on 2.4 but should work with 2.5 without problems
+  // see https://github.com/akka/akka-http/issues/821
+  "com.typesafe.akka" %% "akka-stream" % "2.5.1",
+  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.1" % "test"
 )
 
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"


### PR DESCRIPTION
Hi,

I upgraded the dependencies.

I didn't touch the code, it should work as before, even though apparently `ActorSubscriber` and `ActorPublisher` are deprecated (but my mastery of Akka Streams is not good enough for me to do something about it :P).