### PR TITLE
Reimplement some parts with nicer use of Akka streams

### DIFF
--- a/src/main/scala/Ctx.scala
+++ b/src/main/scala/Ctx.scala
@@ -1,14 +1,14 @@
 import akka.NotUsed
-import akka.util.Timeout
-import schema.MutationError
 import akka.actor.ActorRef
-import generic.Event
-import generic.MemoryEventStore._
-import generic.View.{Get, GetMany}
 import akka.pattern.ask
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
+import akka.util.Timeout
+import generic.Event
+import generic.MemoryEventStore._
+import generic.View.{Get, GetMany}
 import org.reactivestreams.Publisher
+import schema.MutationError
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -23,6 +23,8 @@ case class Ctx(
   implicit def executionContext = ec
   implicit def timeout = to
 
+  // this ensure that slow subscribers does not slow down other subscribers
+  // by buffering the events that arrive too fast
   lazy val eventStream: Source[Event, NotUsed] =
     Source.fromPublisher(eventStorePublisher).buffer(100, OverflowStrategy.fail)
 
@@ -53,6 +55,22 @@ case class Ctx(
         version + 1
       case _ ⇒
         throw MutationError(s"Entity with ID '$id' does not exist.")
+    }
+
+  def loadAuthor(id: String) =
+     (authors ? Get(id)) map {
+      case Some(author: Author) ⇒
+        author
+      case _ ⇒
+        throw MutationError(s"Author with ID '$id' does not exist.")
+    }
+
+  def loadArticle(id: String) =
+    (articles ? Get(id)) map {
+      case Some(article: Article) =>
+        article
+      case _ ⇒
+        throw MutationError(s"Article with ID '$id' does not exist.")
     }
 
   def loadAuthors(ids: Seq[String]) =


### PR DESCRIPTION
Hi,

Finally, here are some refactoring of the code to better work with latest akka :)

After many tries, I couldn't remove the use of the ActorPublisher for the event store because it is much more elegant to manage the buffer inside it and send events when needed as it is already implemented.
I tested using a `Source.queue()` to decouple the buffering from the actor itself, but then I had to take care of concurrency access to the actor state with respect to `offer()` success.

Hope you like it, I also did some cleaning to uniformise things in mutations and in the event store which were not really needed, but now it's nicer I think. I can extract them in other PRs if you prefer :)