### PR TITLE
Add EventSource polyfill

### DIFF
--- a/src/main/resources/web/client.html
+++ b/src/main/resources/web/client.html
@@ -12,6 +12,7 @@
   <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400,700' rel='stylesheet' type='text/css'>
 
   <script src="//code.jquery.com/jquery-2.2.1.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/event-source-polyfill/0.0.9/eventsource.min.js"></script>
   <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 
   <style>


### PR DESCRIPTION
Added [polyfill](https://github.com/Yaffle/EventSource) to make EventSource work on Edge, IE and some older browser versions.