### PR TITLE
Upgrade sbt and sbt-revolver so that it works in current year -- 2020

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")


### PR DESCRIPTION
13:10 https://github.com/sbt/sbt/issues/5452
  use sbt.version=1.3.8 at project/build.properties

13:14 [error] sbt.librarymanagement.ResolveException: Error downloading io.spray:sbt-revolver;sbtVersion=1.0;scalaVersion=2.12:0.8.0
  use addSbtPlugin(io.spray % sbt-revolver % 0.9.1) at project/plugins.sbt