### PR TITLE
General Update: Scala, Akka, Akka Stream, Sangria.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .idea_modules
 
 # sbt specific
+.bloop
+.bsp
+.metals
 dist/*
 target/
 lib_managed/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = "3.7.15"
+runner.dialect = scala213
+maxColumn = 120

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This uses an [sbt-revolver](https://github.com/spray/sbt-revolver) plugin. It wi
    
 After you started the server, you can point your browser to following URLs:
  
-* [http://localhost:8080](http://localhost:8080) - GraphiQL UI
-* [http://localhost:8080/client](http://localhost:8080/client) - Simple Server Sent Events GraphQL client that will stream events based on subscription query. 
+* [http://localhost:8084](http://localhost:8084) - GraphiQL UI
+* [http://localhost:8084/client](http://localhost:8084/client) - Simple Server Sent Events GraphQL client that will stream events based on subscription query. 
 
 ## High-level overview
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,19 @@ description := "Sangria Subscriptions Example"
 scalaVersion := "2.13.14"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
+lazy val akkaStreamVersion = "2.8.0"
+lazy val akkaHttpVersion = "10.5.3"
+
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "2.0.0",
+  "org.sangria-graphql" %% "sangria" % "4.1.1",
   "org.sangria-graphql" %% "sangria-spray-json" % "1.0.3",
   "org.sangria-graphql" %% "sangria-akka-streams" % "1.0.2",
-  "com.typesafe.akka" %% "akka-http" % "10.5.1",
-  "com.typesafe.akka" %% "akka-http-spray-json" % "10.5.1",
+  "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
   "com.lightbend.akka" %% "akka-stream-alpakka-sse" % "6.0.1",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "com.typesafe.akka" %% "akka-stream" % "2.5.23",
-  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.23" % "test"
+  "com.typesafe.akka" %% "akka-stream" % akkaStreamVersion,
+  "com.typesafe.akka" %% "akka-stream-testkit" % akkaStreamVersion % "test",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"

--- a/build.sbt
+++ b/build.sbt
@@ -3,24 +3,19 @@ version := "0.1.0-SNAPSHOT"
 
 description := "Sangria Subscriptions Example"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.13.14"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.2.0",
-  "org.sangria-graphql" %% "sangria-spray-json" % "1.0.0",
-  "org.sangria-graphql" %% "sangria-akka-streams" % "1.0.0",
-
-  "com.typesafe.akka" %% "akka-http" % "10.0.6",
-  "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.6",
-  "de.heikoseeberger" %% "akka-sse" % "2.0.0",
-
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-
-  // akka-http still depends on 2.4 but should work with 2.5 without problems
-  // see https://github.com/akka/akka-http/issues/821
-  "com.typesafe.akka" %% "akka-stream" % "2.5.1",
-  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.1" % "test"
+  "org.sangria-graphql" %% "sangria" % "2.0.0",
+  "org.sangria-graphql" %% "sangria-spray-json" % "1.0.3",
+  "org.sangria-graphql" %% "sangria-akka-streams" % "1.0.2",
+  "com.typesafe.akka" %% "akka-http" % "10.5.1",
+  "com.typesafe.akka" %% "akka-http-spray-json" % "10.5.1",
+  "com.lightbend.akka" %% "akka-stream-alpakka-sse" % "6.0.1",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "com.typesafe.akka" %% "akka-stream" % "2.5.23",
+  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.23" % "test"
 )
 
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.10.1

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,8 @@
+// format: off
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.18")
+
+// format: on

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,0 +1,8 @@
+// format: off
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.18")
+
+// format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,0 +1,8 @@
+// format: off
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.18")
+
+// format: on

--- a/src/main/scala/Ctx.scala
+++ b/src/main/scala/Ctx.scala
@@ -1,5 +1,4 @@
 import akka.NotUsed
-import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
@@ -8,59 +7,72 @@ import generic.Event
 import generic.MemoryEventStore._
 import generic.View.{Get, GetMany}
 import schema.MutationError
+import generic.{MemoryEventStore}
 
 import scala.concurrent.{ExecutionContext, Future}
+import akka.actor.AbstractActor.Receive
+import akka.actor.{Props, ActorSystem, ActorRef, Actor, Stash}
+import Server.logger
 
 case class Ctx(
-  authors: ActorRef,
-  articles: ActorRef,
-  eventStore: ActorRef,
-  events: Source[Event, NotUsed],
-  ec: ExecutionContext,
-  to: Timeout
-) extends Mutation {
-  implicit def executionContext = ec
-  implicit def timeout = to
+    authors: ActorRef,
+    articles: ActorRef,
+    eventStore: ActorRef,
+    events: Source[Event, NotUsed],
+    ec: ExecutionContext,
+    to: Timeout
+)(implicit system: ActorSystem)
+    extends Mutation {
+  implicit def executionContext: ExecutionContext = ec
+  implicit def timeout: Timeout = to
 
   // this ensure that slow subscribers does not slow down other subscribers
   // by buffering the events that arrive too fast
   lazy val eventStream: Source[Event, NotUsed] =
     events.buffer(100, OverflowStrategy.fail)
 
-  def addEvent[T](view: ActorRef, event: Event) =
-    (eventStore ? AddEvent(event)).flatMap {
-      case EventAdded(_) ⇒
-        (view ? Get(event.id, Some(event.version))).mapTo[Option[T]]
-      case OverCapacity(_) ⇒
-        throw MutationError("Service is overloaded.")
-      case ConcurrentModification(_, latestVersion) ⇒
-        throw MutationError(s"Concurrent Modification error for entity '${event.id}'. Latest entity version is '$latestVersion'.")
-    }
+  def addEvent[T](view: ActorRef, event: Event) = {
+    (eventStore ? AddEvent(event))
+      .flatMap {
+        case EventAdded(_) =>
+          (view ? Get(event.id, Some(event.version))).mapTo[Option[T]]
+        case OverCapacity(_) =>
+          throw MutationError("Service is overloaded.")
+        case ConcurrentModification(_, latestVersion) =>
+          throw MutationError(
+            s"Concurrent Modification error for entity '${event.id}'. Latest entity version is '$latestVersion'."
+          )
+      }
+  }
 
   def addDeleteEvent(event: Event) =
     (eventStore ? AddEvent(event)).map {
-      case EventAdded(e) ⇒  e
-      case OverCapacity(_) ⇒
+      case EventAdded(e) => e
+      case OverCapacity(_) =>
         throw MutationError("Service is overloaded.")
-      case ConcurrentModification(_, latestVersion) ⇒
-        throw MutationError(s"Concurrent Modification error for entity '${event.id}'. Latest entity version is '$latestVersion'.")
+      case ConcurrentModification(_, latestVersion) =>
+        throw MutationError(
+          s"Concurrent Modification error for entity '${event.id}'. Latest entity version is '$latestVersion'."
+        )
     }
 
   def loadLatestVersion(id: String, version: Long): Future[Long] =
     (eventStore ? LatestEventVersion(id)) map {
-      case Some(latestVersion: Long) if version != latestVersion ⇒
-        throw MutationError(s"Concurrent Modification error for entity '$id'. Latest entity version is '$latestVersion'.")
-      case Some(version: Long) ⇒
+      case Some(latestVersion: Long) if version != latestVersion =>
+        throw MutationError(
+          s"Concurrent Modification error for entity '$id'. Latest entity version is '$latestVersion'."
+        )
+      case Some(version: Long) =>
         version + 1
-      case _ ⇒
+      case _ =>
         throw MutationError(s"Entity with ID '$id' does not exist.")
     }
 
   def loadAuthor(id: String) =
-     (authors ? Get(id)) map {
-      case Some(author: Author) ⇒
+    (authors ? Get(id)) map {
+      case Some(author: Author) =>
         author
-      case _ ⇒
+      case _ =>
         throw MutationError(s"Author with ID '$id' does not exist.")
     }
 
@@ -68,7 +80,7 @@ case class Ctx(
     (articles ? Get(id)) map {
       case Some(article: Article) =>
         article
-      case _ ⇒
+      case _ =>
         throw MutationError(s"Article with ID '$id' does not exist.")
     }
 

--- a/src/main/scala/Mutation.scala
+++ b/src/main/scala/Mutation.scala
@@ -5,7 +5,7 @@ import sangria.macros.derive.GraphQLField
 import scala.concurrent.Future
 
 trait Mutation {
-  this: Ctx ⇒
+  this: Ctx =>
 
   @GraphQLField
   def createAuthor(firstName: String, lastName: String): Future[Option[Author]] =
@@ -14,37 +14,37 @@ trait Mutation {
   @GraphQLField
   def changeAuthorName(id: String, version: Long, firstName: String, lastName: String): Future[Option[Author]] =
     for {
-      nextVersion ← loadLatestVersion(id, version)
-      author ← addEvent[Author](authors, AuthorNameChanged(id, nextVersion, firstName, lastName))
+      nextVersion <- loadLatestVersion(id, version)
+      author <- addEvent[Author](authors, AuthorNameChanged(id, nextVersion, firstName, lastName))
     } yield author
 
   @GraphQLField
   def deleteAuthor(id: String, version: Long): Future[Author] =
     for {
-      nextVersion ← loadLatestVersion(id, version)
-      author ← loadAuthor(id)
-      _ ← addDeleteEvent(AuthorDeleted(id, nextVersion))
+      nextVersion <- loadLatestVersion(id, version)
+      author <- loadAuthor(id)
+      _ <- addDeleteEvent(AuthorDeleted(id, nextVersion))
     } yield author
 
   @GraphQLField
   def createArticle(title: String, authorId: String, text: Option[String]): Future[Option[Article]] =
     for {
-      author ← loadAuthor(authorId)
-      article ← addEvent[Article](articles, ArticleCreated(UUID.randomUUID.toString, 1, title, author.id, text))
+      author <- loadAuthor(authorId)
+      article <- addEvent[Article](articles, ArticleCreated(UUID.randomUUID.toString, 1, title, author.id, text))
     } yield article
 
   @GraphQLField
   def changeArticleText(id: String, version: Long, text: Option[String]): Future[Option[Article]] =
     for {
-      nextVersion ← loadLatestVersion(id, version)
-      article ← addEvent[Article](articles, ArticleTextChanged(id, nextVersion, text))
+      nextVersion <- loadLatestVersion(id, version)
+      article <- addEvent[Article](articles, ArticleTextChanged(id, nextVersion, text))
     } yield article
 
   @GraphQLField
   def deleteArticle(id: String, version: Long) =
     for {
-      version ← loadLatestVersion(id, version)
-      article ← loadArticle(id)
-      _ ← addDeleteEvent(ArticleDeleted(id, version))
+      version <- loadLatestVersion(id, version)
+      article <- loadArticle(id)
+      _ <- addDeleteEvent(ArticleDeleted(id, version))
     } yield article
 }

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -1,4 +1,4 @@
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{Props, ActorSystem, ActorRef, Actor, Stash}
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -7,11 +7,9 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.ActorMaterializer
-import akka.stream.actor.ActorPublisher
+import akka.stream.stage.GraphStage
 import akka.stream.scaladsl.{BroadcastHub, Keep, Source}
 import akka.util.Timeout
-import de.heikoseeberger.akkasse.EventStreamMarshalling._
-import de.heikoseeberger.akkasse._
 import generic.{Event, MemoryEventStore, View}
 import sangria.ast.OperationType
 import sangria.execution.deferred.DeferredResolver
@@ -20,29 +18,45 @@ import sangria.marshalling.sprayJson._
 import sangria.parser.{QueryParser, SyntaxError}
 import spray.json._
 
+import akka.pattern.{ask, pipe}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import akka.http.scaladsl.marshalling.sse.EventStreamMarshalling._
 
 object Server extends App {
-  implicit val system = ActorSystem("server")
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("server")
   val logger = Logging(system, getClass)
 
   import system.dispatcher
 
-  implicit val timeout = Timeout(10 seconds)
+  implicit val timeout: Timeout = Timeout(10 seconds)
 
-  val articlesView = system.actorOf(Props[ArticleView])
-  val authorsView = system.actorOf(Props[AuthorView])
-  val eventStore = system.actorOf(Props[MemoryEventStore])
+  val articlesView = system.actorOf(Props[ArticleView]())
+  val authorsView = system.actorOf(Props[AuthorView]())
+  val eventStoreFeeder: ActorRef = system.actorOf(Props(new Actor with Stash {
+    def receive: Receive = {
+      case MemoryEventStore.AssignStageActor(stageActor: ActorRef) =>
+        unstashAll()
+        context.become(receiveNew(stageActor))
+      case _ => stash()
+    }
+
+    def receiveNew(memoryStoreActor: ActorRef): Receive = { event =>
+      (memoryStoreActor ? event).pipeTo(sender())
+    }
+
+  }))
+  val eventStore = new MemoryEventStore(sourceFeeder = eventStoreFeeder);
 
   // this a stream with an actor as a source
   // and a broadcast hub to send them to views and dynamic subscriptions
   val events = Source
-    .fromPublisher(ActorPublisher[Event](eventStore))
-    .toMat(BroadcastHub.sink)(Keep.right).run()
+    .fromGraph(eventStore)
+    .toMat(BroadcastHub.sink)(Keep.right)
+    .run()
 
   // Connect event store to views
   View.asSink(articlesView).runWith(events)
@@ -51,86 +65,101 @@ object Server extends App {
   val executor = Executor(schema.createSchema, deferredResolver = DeferredResolver.fetchers(schema.authors))
 
   def executeQuery(query: String, operation: Option[String], variables: JsObject = JsObject.empty): Route = {
-    val ctx = Ctx(authorsView, articlesView, eventStore, events, system.dispatcher, timeout)
+    val ctx = Ctx(authorsView, articlesView, eventStoreFeeder, events, system.dispatcher, timeout)
 
     QueryParser.parse(query) match {
       // Query is parsed successfully, let's execute it
-      case Success(queryAst) ⇒
+      case Success(queryAst) =>
         queryAst.operationType(operation) match {
 
           // subscription queries will produce `text/event-stream` response
-          case Some(OperationType.Subscription) ⇒
+          case Some(OperationType.Subscription) =>
             import sangria.execution.ExecutionScheme.Stream
             import sangria.streaming.akkaStreams._
 
             complete(
-              executor.prepare(queryAst, ctx, (), operation, variables)
-                .map { preparedQuery ⇒
-                  ToResponseMarshallable(preparedQuery.execute()
-                    .map(result ⇒ ServerSentEvent(result.compactPrint))
-                    .recover { case NonFatal(error) ⇒
-                      logger.error(error, "Unexpected error during event stream processing.")
-                      ServerSentEvent(error.getMessage)
-                    })
+              executor
+                .prepare(queryAst, ctx, (), operation, variables)
+                .map { preparedQuery =>
+                  ToResponseMarshallable(
+                    preparedQuery
+                      .execute()
+                      .map(result => ServerSentEvent(result.compactPrint))
+                      .recover { case NonFatal(error) =>
+                        logger.error(error, "Unexpected error during event stream processing.")
+                        ServerSentEvent(error.getMessage)
+                      }
+                  )
                 }
                 .recover {
-                  case error: QueryAnalysisError ⇒ ToResponseMarshallable(BadRequest → error.resolveError)
-                  case error: ErrorWithResolver ⇒ ToResponseMarshallable(InternalServerError → error.resolveError)
-                })
+                  case error: QueryAnalysisError => ToResponseMarshallable(BadRequest -> error.resolveError)
+                  case error: ErrorWithResolver  => ToResponseMarshallable(InternalServerError -> error.resolveError)
+                }
+            )
 
           // all other queries will just return normal JSON response
-          case _ ⇒
-            complete(executor.execute(queryAst, ctx, (), operation, variables)
-              .map(OK → _)
-              .recover {
-                case error: QueryAnalysisError ⇒ BadRequest → error.resolveError
-                case error: ErrorWithResolver ⇒ InternalServerError → error.resolveError
-              })
+          case _ =>
+            complete(
+              executor
+                .execute(queryAst, ctx, (), operation, variables)
+                .map(OK -> _)
+                .recover {
+                  case error: QueryAnalysisError => BadRequest -> error.resolveError
+                  case error: ErrorWithResolver  => InternalServerError -> error.resolveError
+                }
+            )
         }
 
       // Query contains syntax errors
-      case Failure(error: SyntaxError) ⇒
-        complete(BadRequest, JsObject(
-          "syntaxError" → JsString(error.getMessage),
-          "locations" → JsArray(JsObject(
-            "line" → JsNumber(error.originalError.position.line),
-            "column" → JsNumber(error.originalError.position.column)))))
+      case Failure(error: SyntaxError) =>
+        complete(
+          BadRequest,
+          JsObject(
+            "syntaxError" -> JsString(error.getMessage),
+            "locations" -> JsArray(
+              JsObject(
+                "line" -> JsNumber(error.originalError.position.line),
+                "column" -> JsNumber(error.originalError.position.column)
+              )
+            )
+          )
+        )
 
-      case Failure(error) ⇒
+      case Failure(error) =>
         complete(InternalServerError)
     }
   }
 
   val route: Route =
     (post & path("graphql")) {
-      entity(as[JsValue]) { requestJson ⇒
+      entity(as[JsValue]) { requestJson =>
         val JsObject(fields) = requestJson
 
         val JsString(query) = fields("query")
 
-        val operation = fields.get("operationName") collect {
-          case JsString(op) ⇒ op
+        val operation = fields.get("operationName") collect { case JsString(op) =>
+          op
         }
 
         val vars = fields.get("variables") match {
-          case Some(obj: JsObject) ⇒ obj
-          case _ ⇒ JsObject.empty
+          case Some(obj: JsObject) => obj
+          case _                   => JsObject.empty
         }
 
         executeQuery(query, operation, vars)
       }
     } ~
-    (get & path("graphql")) {
-      parameters('query, 'operation.?) { (query, operation) ⇒
-        executeQuery(query, operation)
+      (get & path("graphql")) {
+        parameters(Symbol("query"), Symbol("operation").?) { (query, operation) =>
+          executeQuery(query, operation)
+        }
+      } ~
+      (get & path("client")) {
+        getFromResource("web/client.html")
+      } ~
+      get {
+        getFromResource("web/graphiql.html")
       }
-    } ~
-    (get & path("client")) {
-      getFromResource("web/client.html")
-    } ~
-    get {
-      getFromResource("web/graphiql.html")
-    }
 
-  Http().bindAndHandle(route, "0.0.0.0", 8084)
+  Http().newServerAt("0.0.0.0", 8084).bindFlow(route)
 }

--- a/src/main/scala/generic/View.scala
+++ b/src/main/scala/generic/View.scala
@@ -1,7 +1,6 @@
 package generic
 
 import akka.actor.{Actor, ActorLogging, ActorRef, PoisonPill}
-import akka.stream.actor.OneByOneRequestStrategy
 import akka.stream.scaladsl.{Flow, Sink}
 
 import scala.collection.immutable.ListMap
@@ -18,60 +17,58 @@ abstract class View[Entity <: Versioned, Ev <: Event: ClassTag] extends Actor wi
   import context.dispatcher
 
   def receive = {
-    case Init ⇒ sender() ! Ack
-    case event: Ev ⇒
+    case Init => sender() ! Ack
+    case event: Ev =>
       if (handleEvent.isDefinedAt(event.asInstanceOf[Ev])) {
         handleEvent(event.asInstanceOf[Ev])
 
-        val waitingKey = event.id → event.version
+        val waitingKey = event.id -> event.version
 
-        waiting.get(waitingKey) foreach { senderRef ⇒
+        waiting.get(waitingKey) foreach { senderRef =>
           senderRef ! entities.get(event.id)
           waiting = waiting.filterNot(_._1 == waitingKey)
         }
       }
       sender() ! Ack
-    case RemoveWaiting(key) ⇒
-      waiting.get(key) foreach { senderRef ⇒
+    case RemoveWaiting(key) =>
+      waiting.get(key) foreach { senderRef =>
         senderRef ! None
         waiting = waiting.filterNot(_._1 == key)
       }
-    case List(offset, limit) ⇒
+    case List(offset, limit) =>
       sender() ! entities.values.slice(offset, offset + limit)
-    case Get(id, None) ⇒
+    case Get(id, None) =>
       sender() ! entities.get(id)
-    case GetMany(ids) ⇒
-      sender() ! entities.collect{case (key, value) if ids.contains(key) ⇒ value}.toVector
-    case Get(id, Some(version)) ⇒
+    case GetMany(ids) =>
+      sender() ! entities.collect { case (key, value) if ids.contains(key) => value }.toVector
+    case Get(id, Some(version)) =>
       entities.get(id) match {
-        case Some(entity) if entity.version == version ⇒
+        case Some(entity) if entity.version == version =>
           sender() ! entities.get(id)
-        case _ ⇒
-          waiting = waiting + ((id → version) → sender())
-          context.system.scheduler.scheduleOnce(5 seconds, self, RemoveWaiting(id → version))
+        case _ =>
+          waiting = waiting + ((id -> version) -> sender())
+          context.system.scheduler.scheduleOnce(5 seconds, self, RemoveWaiting(id -> version))
       }
   }
 
   def add(entity: Entity) =
-    entities = entities + (entity.id → entity)
+    entities = entities + (entity.id -> entity)
 
-  def update(event: Ev)(fn: Entity ⇒ Entity) =
-    change(event)(entity ⇒ entities = entities.updated(entity.id, fn(entity)))
+  def update(event: Ev)(fn: Entity => Entity) =
+    change(event)(entity => entities = entities.updated(entity.id, fn(entity)))
 
   def delete(event: Ev) =
-    change(event)(entity ⇒ entities = entities.filterNot(_._1 == entity.id))
+    change(event)(entity => entities = entities.filterNot(_._1 == entity.id))
 
-  private def change(event: Ev)(fn: Entity ⇒ Unit) =
+  private def change(event: Ev)(fn: Entity => Unit) =
     entities.get(event.id) match {
-      case Some(entity) if entity.version != event.version - 1 ⇒
+      case Some(entity) if entity.version != event.version - 1 =>
         log.error(s"Entity ${event.id}: version mismatch: expected ${entity.version + 1}, but got ${event.version}")
-      case Some(entity) ⇒
+      case Some(entity) =>
         fn(entity)
-      case None ⇒
+      case None =>
         log.error(s"Entity ${event.id}: not found")
     }
-
-  val requestStrategy = OneByOneRequestStrategy
 
   def handleEvent: Handler
 
@@ -82,8 +79,8 @@ object View {
 
   def asSink[Ev <: Event: ClassTag](view: ActorRef) = {
     Flow[Event]
-      .collect{ case e: Ev ⇒ e }
-      .to(Sink.actorRefWithAck(view, View.Init, View.Ack, PoisonPill))
+      .collect { case e: Ev => e }
+      .to(Sink.actorRefWithBackpressure(view, View.Init, View.Ack, PoisonPill, e => s"Error ${e}"))
   }
 
   case class List(offset: Int, limit: Int)

--- a/src/main/scala/schema.scala
+++ b/src/main/scala/schema.scala
@@ -15,18 +15,26 @@ import sangria.streaming.akkaStreams._
 object schema {
   case class MutationError(message: String) extends Exception(message) with UserFacingError
 
-  val authors = Fetcher.caching((c: Ctx, ids: Seq[String]) ⇒ c.loadAuthors(ids))(HasId(_.id))
+  val authors = Fetcher.caching((c: Ctx, ids: Seq[String]) => c.loadAuthors(ids))(HasId(_.id))
 
   def createSchema(implicit timeout: Timeout, ec: ExecutionContext, mat: Materializer) = {
-    val VersionedType = InterfaceType("Versioned", fields[Ctx, Versioned](
-      Field("id", StringType, resolve = _.value.id),
-      Field("version", LongType, resolve = _.value.version)))
+    val VersionedType = InterfaceType(
+      "Versioned",
+      fields[Ctx, Versioned](
+        Field("id", StringType, resolve = _.value.id),
+        Field("version", LongType, resolve = _.value.version)
+      )
+    )
 
     implicit val AuthorType = deriveObjectType[Unit, Author](Interfaces(VersionedType))
 
-    val EventType = InterfaceType("Event", fields[Ctx, Event](
-      Field("id", StringType, resolve = _.value.id),
-      Field("version", LongType, resolve = _.value.version)))
+    val EventType = InterfaceType(
+      "Event",
+      fields[Ctx, Event](
+        Field("id", StringType, resolve = _.value.id),
+        Field("version", LongType, resolve = _.value.version)
+      )
+    )
 
     val AuthorCreatedType = deriveObjectType[Unit, AuthorCreated](Interfaces(EventType))
     val AuthorNameChangedType = deriveObjectType[Unit, AuthorNameChanged](Interfaces(EventType))
@@ -34,55 +42,76 @@ object schema {
 
     val ArticleCreatedType = deriveObjectType[Unit, ArticleCreated](
       Interfaces(EventType),
-      ReplaceField("authorId", Field("author", OptionType(AuthorType),
-        resolve = c ⇒ authors.deferOpt(c.value.authorId))))
+      ReplaceField(
+        "authorId",
+        Field("author", OptionType(AuthorType), resolve = c => authors.deferOpt(c.value.authorId))
+      )
+    )
 
     val ArticleTextChangedType = deriveObjectType[Unit, ArticleTextChanged](Interfaces(EventType))
     val ArticleDeletedType = deriveObjectType[Unit, ArticleDeleted](Interfaces(EventType))
 
     implicit val ArticleType = deriveObjectType[Ctx, Article](
       Interfaces(VersionedType),
-      ReplaceField("authorId", Field("author", OptionType(AuthorType),
-        resolve = c ⇒ authors.deferOpt(c.value.authorId))))
+      ReplaceField(
+        "authorId",
+        Field("author", OptionType(AuthorType), resolve = c => authors.deferOpt(c.value.authorId))
+      )
+    )
 
     val IdArg = Argument("id", StringType)
     val OffsetArg = Argument("offset", OptionInputType(IntType), 0)
     val LimitArg = Argument("limit", OptionInputType(IntType), 100)
 
-    def entityFields[T](name: String, tpe: ObjectType[Ctx, T], actor: Ctx ⇒ ActorRef) = fields[Ctx, Unit](
-      Field(name, OptionType(tpe),
+    def entityFields[T](name: String, tpe: ObjectType[Ctx, T], actor: Ctx => ActorRef) = fields[Ctx, Unit](
+      Field(
+        name,
+        OptionType(tpe),
         arguments = IdArg :: Nil,
-        resolve = c ⇒ (actor(c.ctx) ? Get(c.arg(IdArg))).mapTo[Option[T]]),
-      Field(name + "s", ListType(tpe),
+        resolve = c => (actor(c.ctx) ? Get(c.arg(IdArg))).mapTo[Option[T]]
+      ),
+      Field(
+        name + "s",
+        ListType(tpe),
         arguments = OffsetArg :: LimitArg :: Nil,
-        resolve = c ⇒ (actor(c.ctx) ? View.List(c.arg(OffsetArg), c.arg(LimitArg))).mapTo[Seq[T]]))
+        resolve = c => (actor(c.ctx) ? View.List(c.arg(OffsetArg), c.arg(LimitArg))).mapTo[Seq[T]]
+      )
+    )
 
-    val QueryType = ObjectType("Query",
+    val QueryType = ObjectType(
+      "Query",
       entityFields[Author]("author", AuthorType, _.authors) ++
-      entityFields[Article]("article", ArticleType, _.articles))
+        entityFields[Article]("article", ArticleType, _.articles)
+    )
 
     val MutationType = deriveContextObjectType[Ctx, Mutation, Unit](identity)
 
     /** creates a subscription field for a specific event type */
     def subscriptionField[T <: Event](tpe: ObjectType[Ctx, T]) = {
-      val fieldName = tpe.name.head.toLower + tpe.name.tail
+      val fieldName = s"${tpe.name.head.toLower}${tpe.name.tail}"
 
-      Field.subs(fieldName, tpe,
-        resolve = (c: Context[Ctx, Unit]) ⇒
+      Field.subs(
+        fieldName,
+        tpe,
+        resolve = (c: Context[Ctx, Unit]) =>
           c.ctx.eventStream
-            .filter(event ⇒ tpe.valClass.isAssignableFrom(event.getClass))
-            .map(event ⇒ Action(event.asInstanceOf[T])))
+            .filter(event => tpe.valClass.isAssignableFrom(event.getClass))
+            .map(event => Action(event.asInstanceOf[T]))
+      )
     }
 
-    val SubscriptionType = ObjectType("Subscription", fields[Ctx, Unit](
-      subscriptionField(AuthorCreatedType),
-      subscriptionField(AuthorNameChangedType),
-      subscriptionField(AuthorDeletedType),
-      subscriptionField(ArticleCreatedType),
-      subscriptionField(ArticleTextChangedType),
-      subscriptionField(ArticleDeletedType),
-      Field.subs("allEvents", EventType, resolve = _.ctx.eventStream.map(Action(_)))
-    ))
+    val SubscriptionType = ObjectType(
+      "Subscription",
+      fields[Ctx, Unit](
+        subscriptionField(AuthorCreatedType),
+        subscriptionField(AuthorNameChangedType),
+        subscriptionField(AuthorDeletedType),
+        subscriptionField(ArticleCreatedType),
+        subscriptionField(ArticleTextChangedType),
+        subscriptionField(ArticleDeletedType),
+        Field.subs("allEvents", EventType, resolve = _.ctx.eventStream.map(Action(_)))
+      )
+    )
 
     Schema(QueryType, Some(MutationType), Some(SubscriptionType))
   }

--- a/src/main/scala/view.scala
+++ b/src/main/scala/view.scala
@@ -2,25 +2,22 @@ import generic.View
 
 class ArticleView extends View[Article, ArticleEvent] {
   val handleEvent: Handler = {
-    case event: ArticleCreated ⇒
+    case event: ArticleCreated =>
       add(Article(event.id, event.version, event.title, event.authorId, event.text))
-    case event: ArticleTextChanged ⇒
+    case event: ArticleTextChanged =>
       update(event)(_.copy(version = event.version, text = event.text))
-    case event: ArticleDeleted ⇒
+    case event: ArticleDeleted =>
       delete(event)
   }
 }
 
 class AuthorView extends View[Author, AuthorEvent] {
   val handleEvent: Handler = {
-    case event: AuthorCreated ⇒
+    case event: AuthorCreated =>
       add(Author(event.id, event.version, event.firstName, event.lastName))
-    case event: AuthorNameChanged ⇒
-      update(event)(_.copy(
-        version = event.version,
-        firstName = event.firstName,
-        lastName = event.lastName))
-    case event: AuthorDeleted ⇒
+    case event: AuthorNameChanged =>
+      update(event)(_.copy(version = event.version, firstName = event.firstName, lastName = event.lastName))
+    case event: AuthorDeleted =>
       delete(event)
   }
 }


### PR DESCRIPTION
The biggest changes in this update are:
- SBT (to 1.10.1)
- Scala version (to 2.13.14).
- Akka.
- Akka Streams.
- Replaced `de.heikoseeberger.akka.sse `to `akka-stream-alpakka-sse`.
- Removed warnings due to library update. (mostly Akka deprecations).
- Refactor at `MemoryEventStore` due to `ActorPublisher` deprecation, replaced with `GraphStage`.


Tested at JDK 21 and sbt version 1.10.0